### PR TITLE
Fix floats

### DIFF
--- a/src/lib/utils/device.ts
+++ b/src/lib/utils/device.ts
@@ -28,7 +28,7 @@ export function decodeParamValue(param: DeviceParam): unknown {
 			case 'Int':
 				return parseInt(decodedString, 10);
 			case 'Float':
-				return parseFloat(decodedString);
+				return parseFloat(parseFloat(decodedString).toFixed(2));
 			case 'Json':
 				return JSON.parse(decodedString);
 			case 'Time':


### PR DESCRIPTION
Parses decodedString into a float so it can be rounded with .toFixed(), then parses the returned string back into a float, eliminating floating-point precision artifacts, such as: https://community.sunnypilot.ai/t/better-support-for-floats-in-sunnylink/2000