### PR TITLE
style: fix prettier formatting in 4 components

### DIFF
--- a/src/lib/components/AlwaysOffroadPrompt.svelte
+++ b/src/lib/components/AlwaysOffroadPrompt.svelte
@@ -8,7 +8,9 @@
 	let deviceId = $derived(deviceState.selectedDeviceId);
 	let offroadStatus = $derived(deviceId ? deviceState.offroadStatuses[deviceId] : undefined);
 	let onlineStatus = $derived(deviceId ? deviceState.onlineStatuses[deviceId] : undefined);
-	let engaged = $derived(deviceId ? (deviceState.deviceTelemetry[deviceId]?.engaged ?? false) : false);
+	let engaged = $derived(
+		deviceId ? (deviceState.deviceTelemetry[deviceId]?.engaged ?? false) : false
+	);
 
 	// Show the prompt only when we have a live reading that the car is actively driving
 	// (isOffroad === false, not undefined) and no forceOffroad override already active.
@@ -40,7 +42,7 @@
 		</div>
 		<button
 			type="button"
-			class="shrink-0 rounded-md border border-amber-500/40 bg-[var(--sl-bg-surface)] px-2.5 py-1 text-[0.75rem] font-medium text-amber-700 transition-all duration-100 hover:bg-amber-500/10 focus-visible:outline-2 focus-visible:outline-amber-500 active:scale-[0.96] active:bg-amber-500/30 dark:text-amber-400 disabled:cursor-not-allowed disabled:opacity-50"
+			class="shrink-0 rounded-md border border-amber-500/40 bg-[var(--sl-bg-surface)] px-2.5 py-1 text-[0.75rem] font-medium text-amber-700 transition-all duration-100 hover:bg-amber-500/10 focus-visible:outline-2 focus-visible:outline-amber-500 active:scale-[0.96] active:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-50 dark:text-amber-400"
 			disabled={engaged}
 			title={engaged ? 'Disengage sunnypilot first' : undefined}
 			onclick={() => (modalOpen = true)}

--- a/src/lib/components/DeviceStatusPill.svelte
+++ b/src/lib/components/DeviceStatusPill.svelte
@@ -638,11 +638,13 @@
 				<button
 					onclick={handleForceOffroadClick}
 					disabled={stoppingForce || (!isForceOffroad && (telemetry?.engaged ?? false))}
-					title={!isForceOffroad && (telemetry?.engaged ?? false) ? 'Disengage sunnypilot first' : undefined}
+					title={!isForceOffroad && (telemetry?.engaged ?? false)
+						? 'Disengage sunnypilot first'
+						: undefined}
 					role="switch"
 					aria-checked={isForceOffroad}
 					aria-label="Always Offroad Mode"
-					class="group flex min-h-[44px] w-full items-center justify-between gap-3 rounded-lg px-2.5 py-2 text-left transition-colors focus-visible:bg-[var(--sl-bg-elevated)] focus-visible:outline-2 focus-visible:outline-primary disabled:opacity-50 disabled:cursor-not-allowed"
+					class="group flex min-h-[44px] w-full items-center justify-between gap-3 rounded-lg px-2.5 py-2 text-left transition-colors focus-visible:bg-[var(--sl-bg-elevated)] focus-visible:outline-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-50"
 				>
 					<span class="text-[0.8125rem] font-medium text-[var(--sl-text-1)]"
 						>Always Offroad Mode</span

--- a/src/lib/components/ForceOffroadModal.svelte
+++ b/src/lib/components/ForceOffroadModal.svelte
@@ -20,7 +20,9 @@
 	let pushing = $state(false);
 	let error = $state<string | null>(null);
 	let confirmed = $state(false);
-	let engaged = $derived(deviceId ? (deviceState.deviceTelemetry[deviceId]?.engaged ?? false) : false);
+	let engaged = $derived(
+		deviceId ? (deviceState.deviceTelemetry[deviceId]?.engaged ?? false) : false
+	);
 
 	$effect(() => {
 		if (open) {

--- a/src/lib/components/schema/SchemaItemRenderer.svelte
+++ b/src/lib/components/schema/SchemaItemRenderer.svelte
@@ -470,7 +470,7 @@
 					</button>
 				{:else}
 					<button
-						class="rounded-full bg-red-500/15 px-4 py-1.5 text-[0.8125rem] font-medium text-red-600 transition-colors hover:bg-red-500/25 focus-visible:outline-2 focus-visible:outline-red-500 active:scale-[0.98] active:bg-red-500/35 dark:text-red-400 disabled:cursor-not-allowed disabled:opacity-50"
+						class="rounded-full bg-red-500/15 px-4 py-1.5 text-[0.8125rem] font-medium text-red-600 transition-colors hover:bg-red-500/25 focus-visible:outline-2 focus-visible:outline-red-500 active:scale-[0.98] active:bg-red-500/35 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400"
 						disabled={!enabled || ruleContext.engaged}
 						title={ruleContext.engaged ? 'Disengage sunnypilot first' : undefined}
 						onclick={() => (offroadConfirmOpen = true)}


### PR DESCRIPTION
## Summary
- Fixes CI lint failure from run [#25468385167](https://github.com/sunnypilot/sunnylink-frontend/actions/runs/25468385167/job/74726620639)
- Runs `prettier --write` on 4 files that had formatting issues: `AlwaysOffroadPrompt.svelte`, `DeviceStatusPill.svelte`, `ForceOffroadModal.svelte`, `SchemaItemRenderer.svelte`