### PR TITLE
fix(search): route results using schema panel.id, add vehicle settings

### DIFF
--- a/src/lib/components/search/CommandPalette.svelte
+++ b/src/lib/components/search/CommandPalette.svelte
@@ -3,14 +3,27 @@
 	import { fade, fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import { deviceState } from '$lib/stores/device.svelte';
+	import { schemaState } from '$lib/stores/schema.svelte';
 	import { searchState } from '$lib/stores/search.svelte';
 	import { getAllSettings } from '$lib/utils/settings';
-	import { searchSettings, type SearchResult } from '$lib/utils/search';
+	import { searchSettings, searchSchemaItems } from '$lib/utils/search';
 	import { MODEL_SETTINGS } from '$lib/types/settings';
 	import { modalLock } from '$lib/utils/modalLock';
 	import { portal } from '$lib/utils/portal';
 	import { goto } from '$app/navigation';
 	import type { FuseResultMatch } from 'fuse.js';
+
+	interface DisplayResult {
+		key: string;
+		anchorKey: string;
+		title: string;
+		description: string;
+		panelId: string;
+		panelLabel: string;
+		subPanelId?: string;
+		score: number;
+		matches?: readonly FuseResultMatch[];
+	}
 
 	const SUGGESTED_QUERIES = ['Cruise', 'Lateral', 'Experimental', 'MADS', 'Models'];
 
@@ -22,17 +35,53 @@
 
 	let deviceId = $derived(deviceState.selectedDeviceId);
 	let settings = $derived(deviceId ? deviceState.deviceSettings[deviceId] : undefined);
+	let deviceValues = $derived(deviceId ? deviceState.deviceValues[deviceId] : undefined);
+	// Legacy fallback — only evaluated when device has no schema.
 	let searchable = $derived(
 		getAllSettings(settings, true, false).filter((s) => !s.hidden || MODEL_SETTINGS.includes(s.key))
 	);
-	let deviceValues = $derived(deviceId ? deviceState.deviceValues[deviceId] : undefined);
 
 	const MIN_QUERY_LENGTH = 3;
 
-	let results: SearchResult[] = $derived.by(() => {
+	let results: DisplayResult[] = $derived.by(() => {
 		const q = searchState.query.trim();
 		if (q.length < MIN_QUERY_LENGTH) return [];
-		return searchSettings(q, searchable, deviceValues).slice(0, 20);
+
+		const schema =
+			deviceId && schemaState.hasSchema(deviceId) ? schemaState.schemas[deviceId] : undefined;
+
+		if (schema) {
+			const currentBrand = schemaState.capabilities[deviceId!]?.brand || undefined;
+			return searchSchemaItems(q, schema, deviceValues, currentBrand).map((r) => ({
+				key: r.item.key,
+				anchorKey: r.item.anchorKey,
+				title: r.item.title,
+				description: r.item.description,
+				panelId: r.item.panelId,
+				panelLabel: r.item.panelLabel,
+				subPanelId: r.item.subPanelId,
+				score: r.score,
+				matches: r.matches
+			}));
+		}
+
+		// Legacy path: SETTINGS_DEFINITIONS for non-schema devices.
+		return searchSettings(q, searchable, deviceValues)
+			.slice(0, 20)
+			.map((r) => {
+				const isModel = MODEL_SETTINGS.includes(r.setting.key);
+				const panelId = isModel ? 'models' : r.setting.category;
+				return {
+					key: r.setting.key,
+					anchorKey: r.setting.key,
+					title: r.setting._extra?.title || r.setting.label,
+					description: r.setting._extra?.description || r.setting.description,
+					panelId,
+					panelLabel: isModel ? 'models' : r.setting.category,
+					score: r.score,
+					matches: r.matches
+				};
+			});
 	});
 
 	$effect(() => {
@@ -85,14 +134,15 @@
 		};
 	});
 
-	function handleSelect(result: SearchResult) {
-		const { setting } = result;
+	function handleSelect(result: DisplayResult) {
 		searchState.pushHistory(searchState.query);
 		searchState.close();
-		if (MODEL_SETTINGS.includes(setting.key)) {
-			goto(`/dashboard/models#${setting.key}`);
+		if (result.panelId === 'models') {
+			goto(`/dashboard/models#${result.anchorKey}`);
+		} else if (result.subPanelId) {
+			goto(`/dashboard/settings/${result.panelId}?panel=${result.subPanelId}#${result.anchorKey}`);
 		} else {
-			goto(`/dashboard/settings/${setting.category}#${setting.key}`);
+			goto(`/dashboard/settings/${result.panelId}#${result.anchorKey}`);
 		}
 	}
 
@@ -198,18 +248,6 @@
 		html += escapeHtml(text.slice(cursor));
 		return html;
 	}
-
-	function categoryLabel(r: SearchResult): string {
-		return MODEL_SETTINGS.includes(r.setting.key) ? 'models' : r.setting.category;
-	}
-
-	function titleOf(r: SearchResult): string {
-		return r.setting._extra?.title || r.setting.label;
-	}
-
-	function descOf(r: SearchResult): string {
-		return r.setting._extra?.description || r.setting.description;
-	}
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -297,7 +335,7 @@
 					</div>
 				{:else if searchState.query.trim()}
 					<ul id="command-palette-list" role="listbox" class="py-1" aria-label="Search results">
-						{#each results as result, i (result.setting.key)}
+						{#each results as result, i (result.key)}
 							{@const active = i === activeIdx}
 							<li role="option" aria-selected={active}>
 								<button
@@ -311,22 +349,22 @@
 								>
 									<span class="flex items-center justify-between gap-3">
 										<span class="truncate text-[0.875rem] font-medium text-[var(--sl-text-1)]">
-											{@html highlight(titleOf(result), 'title', result.matches)}
+											{@html highlight(result.title, 'title', result.matches)}
 										</span>
 										<span
 											class="shrink-0 rounded-md bg-[var(--sl-bg-input)] px-1.5 py-0.5 text-[0.6875rem] font-medium text-[var(--sl-text-3)] capitalize"
 										>
-											{categoryLabel(result)}
+											{result.panelLabel}
 										</span>
 									</span>
-									{#if result.setting.key !== titleOf(result)}
+									{#if result.key !== result.title}
 										<span class="truncate font-mono text-[0.75rem] text-[var(--sl-text-3)]">
-											{@html highlight(result.setting.key, 'key', result.matches)}
+											{@html highlight(result.key, 'key', result.matches)}
 										</span>
 									{/if}
-									{#if descOf(result)}
+									{#if result.description}
 										<span class="line-clamp-2 text-[0.8125rem] text-[var(--sl-text-2)]">
-											{@html highlight(descOf(result), 'description', result.matches)}
+											{@html highlight(result.description, 'description', result.matches)}
 										</span>
 									{/if}
 								</button>

--- a/src/lib/components/search/CommandPalette.svelte
+++ b/src/lib/components/search/CommandPalette.svelte
@@ -36,7 +36,7 @@
 	let deviceId = $derived(deviceState.selectedDeviceId);
 	let settings = $derived(deviceId ? deviceState.deviceSettings[deviceId] : undefined);
 	let deviceValues = $derived(deviceId ? deviceState.deviceValues[deviceId] : undefined);
-	// Legacy fallback — only evaluated when device has no schema.
+	// Legacy fallback, only used when the device has no schema.
 	let searchable = $derived(
 		getAllSettings(settings, true, false).filter((s) => !s.hidden || MODEL_SETTINGS.includes(s.key))
 	);

--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -68,8 +68,8 @@ function getFuse(settings: readonly RenderableSetting[]): Fuse<SearchRecord> {
 
 export interface SchemaItemRecord {
 	key: string;
-	/** Key to use for URL fragment (#anchor). Differs from key for sub_items,
-	 *  which anchor to their parent (sub_items have no DOM id of their own). */
+	/** The key used in the URL fragment (#key). For sub_items this is the parent's key,
+	 *  since sub_items don't get their own DOM id. */
 	anchorKey: string;
 	title: string;
 	description: string;
@@ -130,7 +130,7 @@ export function buildSchemaRecords(schema: SettingsSchema): SchemaItemRecord[] {
 			for (const sub of item.sub_items ?? []) {
 				records.push({
 					key: sub.key,
-					anchorKey: item.key, // sub_items have no own DOM id; scroll to parent
+					anchorKey: item.key, // sub_items don't get their own DOM id; anchor to parent
 					title: sub.title ?? sub.key,
 					description: sub.description ?? '',
 					panelId,
@@ -152,7 +152,7 @@ export function buildSchemaRecords(schema: SettingsSchema): SchemaItemRecord[] {
 		}
 	}
 
-	// Vehicle-specific settings — all brands indexed, filtered post-search by currentBrand.
+	// Vehicle-specific settings: all brands are indexed here, filtered post-search by currentBrand.
 	for (const [brand, brandData] of Object.entries(schema.vehicle_settings ?? {})) {
 		const panelLabel = brandData.title ?? brand;
 		for (const item of brandData.items ?? []) {

--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -1,5 +1,6 @@
 import Fuse, { type IFuseOptions, type FuseResultMatch } from 'fuse.js';
 import type { RenderableSetting } from '$lib/types/settings';
+import type { SettingsSchema } from '$lib/types/schema';
 
 export interface SearchResult {
 	setting: RenderableSetting;
@@ -62,6 +63,164 @@ function getFuse(settings: readonly RenderableSetting[]): Fuse<SearchRecord> {
 	}
 	return fuse;
 }
+
+// ─── Schema-first search ──────────────────────────────────────────────────────
+
+export interface SchemaItemRecord {
+	key: string;
+	/** Key to use for URL fragment (#anchor). Differs from key for sub_items,
+	 *  which anchor to their parent (sub_items have no DOM id of their own). */
+	anchorKey: string;
+	title: string;
+	description: string;
+	panelId: string;
+	panelLabel: string;
+	subPanelId?: string;
+	/** Set only for vehicle_settings items. Used to filter to current device brand. */
+	brand?: string;
+}
+
+export interface SchemaSearchResult {
+	item: SchemaItemRecord;
+	score: number;
+	matches?: readonly FuseResultMatch[];
+}
+
+const SCHEMA_FUSE_OPTIONS: IFuseOptions<SchemaItemRecord> = {
+	keys: [
+		{ name: 'title', weight: 0.5 },
+		{ name: 'key', weight: 0.3 },
+		{ name: 'description', weight: 0.15 },
+		{ name: 'panelLabel', weight: 0.05 }
+	],
+	threshold: 0.3,
+	ignoreLocation: true,
+	minMatchCharLength: 3,
+	useExtendedSearch: true,
+	includeScore: true,
+	includeMatches: true
+};
+
+const schemaFuseCache = new WeakMap<SettingsSchema, Fuse<SchemaItemRecord>>();
+
+export function buildSchemaRecords(schema: SettingsSchema): SchemaItemRecord[] {
+	const records: SchemaItemRecord[] = [];
+
+	for (const panel of schema.panels) {
+		const { id: panelId, label: panelLabel } = panel;
+
+		function addItem(
+			item: {
+				key: string;
+				title?: string;
+				description?: string;
+				sub_items?: { key: string; title?: string; description?: string }[];
+			},
+			subPanelId?: string
+		) {
+			records.push({
+				key: item.key,
+				anchorKey: item.key,
+				title: item.title ?? item.key,
+				description: item.description ?? '',
+				panelId,
+				panelLabel,
+				subPanelId
+			});
+			for (const sub of item.sub_items ?? []) {
+				records.push({
+					key: sub.key,
+					anchorKey: item.key, // sub_items have no own DOM id; scroll to parent
+					title: sub.title ?? sub.key,
+					description: sub.description ?? '',
+					panelId,
+					panelLabel,
+					subPanelId
+				});
+			}
+		}
+
+		for (const item of panel.items ?? []) addItem(item);
+		for (const sp of panel.sub_panels ?? []) {
+			for (const item of sp.items) addItem(item, sp.id);
+		}
+		for (const section of panel.sections ?? []) {
+			for (const item of section.items) addItem(item);
+			for (const sp of section.sub_panels ?? []) {
+				for (const item of sp.items) addItem(item, sp.id);
+			}
+		}
+	}
+
+	// Vehicle-specific settings — all brands indexed, filtered post-search by currentBrand.
+	for (const [brand, brandData] of Object.entries(schema.vehicle_settings ?? {})) {
+		const panelLabel = brandData.title ?? brand;
+		for (const item of brandData.items ?? []) {
+			records.push({
+				key: item.key,
+				anchorKey: item.key,
+				title: item.title ?? item.key,
+				description: item.description ?? '',
+				panelId: 'vehicle',
+				panelLabel,
+				brand
+			});
+			for (const sub of item.sub_items ?? []) {
+				records.push({
+					key: sub.key,
+					anchorKey: item.key,
+					title: sub.title ?? sub.key,
+					description: sub.description ?? '',
+					panelId: 'vehicle',
+					panelLabel,
+					brand
+				});
+			}
+		}
+	}
+
+	return records;
+}
+
+function getSchemaFuse(schema: SettingsSchema): Fuse<SchemaItemRecord> {
+	let fuse = schemaFuseCache.get(schema);
+	if (!fuse) {
+		fuse = new Fuse(buildSchemaRecords(schema), SCHEMA_FUSE_OPTIONS);
+		schemaFuseCache.set(schema, fuse);
+	}
+	return fuse;
+}
+
+export function searchSchemaItems(
+	query: string,
+	schema: SettingsSchema,
+	values?: Record<string, unknown>,
+	currentBrand?: string
+): SchemaSearchResult[] {
+	const q = query.trim();
+	if (!q) return [];
+
+	const hits = getSchemaFuse(schema).search(q);
+	const normalized = q.toLowerCase();
+
+	return (
+		hits
+			.map((hit): SchemaSearchResult => {
+				const baseScore = (1 - (hit.score ?? 1)) * 100;
+				const raw = values?.[hit.item.key];
+				const valueStr = raw !== undefined && raw !== null ? String(raw).toLowerCase() : '';
+				const valueBonus = valueStr && valueStr.includes(normalized) ? 5 : 0;
+				return { item: hit.item, score: baseScore + valueBonus, matches: hit.matches };
+			})
+			.filter((r) => r.score >= MIN_MATCH_SCORE)
+			// Vehicle settings: only surface results for the connected device's brand.
+			.filter((r) => !r.item.brand || !currentBrand || r.item.brand === currentBrand)
+			.sort((a, b) => b.score - a.score)
+			.slice(0, 20)
+	);
+}
+
+// ─── Legacy search (SETTINGS_DEFINITIONS path for non-schema devices) ─────────
 
 export function searchSettings(
 	query: string,

--- a/src/routes/dashboard/settings/vehicle/+page.svelte
+++ b/src/routes/dashboard/settings/vehicle/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import { deviceState } from '$lib/stores/device.svelte';
 	import { schemaState } from '$lib/stores/schema.svelte';
 	import { logtoClient } from '$lib/logto/auth.svelte';
@@ -69,6 +70,7 @@
 	// Fetch brand setting values when brand settings are available
 	let loadingBrandValues = $state(false);
 	let brandValuesFetchFailed = $state(false);
+	let brandValuesVerified = $state(false);
 
 	$effect(() => {
 		if (deviceId && logtoClient && brandSettings.length > 0) {
@@ -82,7 +84,10 @@
 		const existing = deviceState.deviceValues[deviceId] ?? {};
 		const keys = brandSettings.map((item) => item.key);
 		const missing = force ? keys : keys.filter((k) => existing[k] === undefined);
-		if (missing.length === 0) return;
+		if (missing.length === 0) {
+			brandValuesVerified = true;
+			return;
+		}
 
 		loadingBrandValues = true;
 		brandValuesFetchFailed = false;
@@ -119,8 +124,25 @@
 			brandValuesFetchFailed = true;
 		} finally {
 			loadingBrandValues = false;
+			brandValuesVerified = true;
 		}
 	}
+
+	// Scroll to hash anchor after brand values are ready (search result deep-link).
+	$effect(() => {
+		if (!brandValuesVerified) return;
+		const hash = page.url.hash.slice(1);
+		if (!hash) return;
+		const timer = window.setTimeout(() => {
+			const el = document.getElementById(hash);
+			if (!el) return;
+			const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			el.scrollIntoView({ block: 'nearest', behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+			el.setAttribute('data-settings-highlight', 'true');
+			window.setTimeout(() => el.removeAttribute('data-settings-highlight'), 2500);
+		}, 200);
+		return () => window.clearTimeout(timer);
+	});
 
 	let schemaRevalStatus = $derived(
 		deviceId ? (schemaState.revalidationStatus[deviceId] ?? null) : null


### PR DESCRIPTION
- Search builds its index from the device schema, so results route to the right panel
- `OnroadScreenOffBrightness`, `DisableUpdates`, and a few others were landing on wrong pages; settings absent from SETTINGS_DEFINITIONS fell through to `category: other` with no panel match
- Vehicle-specific settings (Hyundai, Subaru, Toyota, Tesla) now show up in search, scoped to the device's current brand
- Vehicle page scrolls to and highlights the target item when opened from a search result