### PR TITLE
Generate dynamic Navigation for `settings_ui.json` pages

### DIFF
--- a/src/lib/components/dashboard/DashboardTiles.svelte
+++ b/src/lib/components/dashboard/DashboardTiles.svelte
@@ -1,34 +1,17 @@
 <script lang="ts">
-	import {
-		HardDrive,
-		ToggleLeft,
-		Bot,
-		Gauge,
-		Wind,
-		Palette,
-		Map as MapIcon,
-		Car,
-		Wrench
-	} from 'lucide-svelte';
+	import { deviceState } from '$lib/stores/device.svelte';
+	import { schemaState } from '$lib/stores/schema.svelte';
+	import { getDashboardNavItems } from '$lib/utils/schemaNav';
 
-	type Tile = { label: string; icon: typeof HardDrive; href: string };
-
-	const TILES: Tile[] = [
-		{ label: 'Device', icon: HardDrive, href: '/dashboard/settings/device' },
-		{ label: 'Toggles', icon: ToggleLeft, href: '/dashboard/settings/toggles' },
-		{ label: 'Models', icon: Bot, href: '/dashboard/models' },
-		{ label: 'Steering', icon: Gauge, href: '/dashboard/settings/steering' },
-		{ label: 'Cruise', icon: Wind, href: '/dashboard/settings/cruise' },
-		{ label: 'Visuals', icon: Palette, href: '/dashboard/settings/visuals' },
-		{ label: 'Maps', icon: MapIcon, href: '/dashboard/osm' },
-		{ label: 'Vehicle', icon: Car, href: '/dashboard/settings/vehicle' },
-		{ label: 'Developer', icon: Wrench, href: '/dashboard/settings/developer' }
-	];
+	let deviceId = $derived(deviceState.selectedDeviceId);
+	let tiles = $derived(
+		deviceId ? getDashboardNavItems(schemaState.schemas[deviceId]) : getDashboardNavItems(undefined)
+	);
 </script>
 
 <nav aria-label="Device features">
 	<ul class="grid list-none grid-cols-3 gap-3 p-0">
-		{#each TILES as tile}
+		{#each tiles as tile}
 			{@const Icon = tile.icon}
 			<li>
 				<a

--- a/src/lib/types/settings.ts
+++ b/src/lib/types/settings.ts
@@ -23,7 +23,8 @@ export type SettingCategory =
 	| 'cruise'
 	| 'visuals'
 	| 'developer'
-	| 'other';
+	| 'other'
+	| (string & {});
 
 export interface SettingDefinition {
 	key: string;

--- a/src/lib/utils/schemaNav.ts
+++ b/src/lib/utils/schemaNav.ts
@@ -1,0 +1,170 @@
+import {
+	Bot,
+	Car,
+	Gauge,
+	HardDrive,
+	Map as MapIcon,
+	Monitor,
+	Package,
+	Palette,
+	ToggleLeft,
+	Wind,
+	Wrench
+} from 'lucide-svelte';
+
+import type { Panel, SettingsSchema } from '$lib/types/schema';
+
+export type NavIcon = typeof HardDrive;
+
+export interface SchemaNavItem {
+	id: string;
+	label: string;
+	href: string;
+	icon: NavIcon;
+	order: number;
+}
+
+const SCHEMA_ICON_MAP: Record<string, NavIcon> = {
+	cruise_control: Wind,
+	developer: Wrench,
+	device: HardDrive,
+	display: Monitor,
+	models: Bot,
+	software: Package,
+	steering_wheel: Gauge,
+	toggles: ToggleLeft,
+	visuals: Palette
+};
+
+const FALLBACK_ICON_BY_PANEL_ID: Record<string, NavIcon> = {
+	cruise: Wind,
+	developer: Wrench,
+	device: HardDrive,
+	display: Monitor,
+	models: Bot,
+	software: Package,
+	steering: Gauge,
+	toggles: ToggleLeft,
+	vehicle: Car,
+	visuals: Palette,
+	osm: MapIcon,
+	maps: MapIcon
+};
+
+const LEGACY_NAV_ITEMS: SchemaNavItem[] = [
+	{
+		id: 'device',
+		label: 'Device',
+		href: '/dashboard/settings/device',
+		icon: HardDrive,
+		order: 0
+	},
+	{
+		id: 'toggles',
+		label: 'Toggles',
+		href: '/dashboard/settings/toggles',
+		icon: ToggleLeft,
+		order: 1
+	},
+	{
+		id: 'models',
+		label: 'Models',
+		href: '/dashboard/models',
+		icon: Bot,
+		order: 2
+	},
+	{
+		id: 'steering',
+		label: 'Steering',
+		href: '/dashboard/settings/steering',
+		icon: Gauge,
+		order: 3
+	},
+	{
+		id: 'cruise',
+		label: 'Cruise',
+		href: '/dashboard/settings/cruise',
+		icon: Wind,
+		order: 4
+	},
+	{
+		id: 'visuals',
+		label: 'Visuals',
+		href: '/dashboard/settings/visuals',
+		icon: Palette,
+		order: 5
+	},
+	{
+		id: 'display',
+		label: 'Display',
+		href: '/dashboard/settings/display',
+		icon: Monitor,
+		order: 6
+	},
+	{
+		id: 'osm',
+		label: 'Maps',
+		href: '/dashboard/osm',
+		icon: MapIcon,
+		order: 7.5
+	},
+	{
+		id: 'vehicle',
+		label: 'Vehicle',
+		href: '/dashboard/settings/vehicle',
+		icon: Car,
+		order: 8
+	},
+	{
+		id: 'software',
+		label: 'Software',
+		href: '/dashboard/settings/software',
+		icon: Package,
+		order: 9
+	},
+	{
+		id: 'developer',
+		label: 'Developer',
+		href: '/dashboard/settings/developer',
+		icon: Wrench,
+		order: 10
+	}
+];
+
+export function getPanelIcon(panel: Pick<Panel, 'id' | 'icon'>): NavIcon {
+	return SCHEMA_ICON_MAP[panel.icon] ?? FALLBACK_ICON_BY_PANEL_ID[panel.id] ?? HardDrive;
+}
+
+function panelHref(panelId: string): string {
+	if (panelId === 'models') return '/dashboard/models';
+	return `/dashboard/settings/${panelId}`;
+}
+
+function panelToNavItem(panel: Panel): SchemaNavItem {
+	return {
+		id: panel.id,
+		label: panel.label,
+		href: panelHref(panel.id),
+		icon: getPanelIcon(panel),
+		order: panel.order
+	};
+}
+
+export function getBuiltinNavItems(): SchemaNavItem[] {
+	return LEGACY_NAV_ITEMS;
+}
+
+export function getCustomSchemaNavItems(schema: SettingsSchema | undefined): SchemaNavItem[] {
+	if (!schema?.panels?.length) return [];
+
+	const builtInHrefs = new Set(LEGACY_NAV_ITEMS.map((item) => item.href));
+
+	return schema.panels
+		.map(panelToNavItem)
+		.filter((item) => !builtInHrefs.has(item.href))
+		.sort((a, b) => a.order - b.order || a.label.localeCompare(b.label));
+}
+
+export function getDashboardNavItems(schema: SettingsSchema | undefined): SchemaNavItem[] {
+	return [...getBuiltinNavItems(), ...getCustomSchemaNavItems(schema)];
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,25 +6,14 @@
 
 	import { authState, logtoClient } from '$lib/logto/auth.svelte';
 	import { deviceState } from '$lib/stores/device.svelte';
+	import { schemaState } from '$lib/stores/schema.svelte';
 	import {
-		Bot,
-		Car,
 		ChevronDown,
-		Gauge,
-		HardDrive,
 		House,
 		LogIn,
 		Loader2,
-		Map as MapIcon,
 		Menu,
-		Monitor,
-		Package,
-		Palette,
-		Settings,
 		Sparkles,
-		ToggleLeft,
-		Wind,
-		Wrench,
 		ArrowLeftRight,
 		Smartphone,
 		X
@@ -54,6 +43,7 @@
 	import { scrollPositions } from '$lib/stores/scrollPositions.svelte';
 	import { whatsNewStore } from '$lib/stores/whatsNew.svelte';
 	import { FEATURES } from '$lib/config/features';
+	import { getBuiltinNavItems, getCustomSchemaNavItems } from '$lib/utils/schemaNav';
 	import { onMount } from 'svelte';
 	import { fade, fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
@@ -202,24 +192,29 @@
 	let settingsOpen = $state(true);
 
 	const getPageTitle = (path: string) => {
-		const titles: Record<string, string> = {
+		const staticTitles: Record<string, string> = {
 			'/': 'Home',
 			'/dashboard': 'Home',
 			'/dashboard/models': 'Models',
-			'/dashboard/settings/device': 'Device Settings',
-			'/dashboard/settings/toggles': 'Toggles',
-			'/dashboard/settings/steering': 'Steering',
-			'/dashboard/settings/cruise': 'Cruise',
-			'/dashboard/settings/visuals': 'Visuals',
 			'/dashboard/settings/vehicle': 'Vehicle',
-			'/dashboard/settings/display': 'Display',
-			'/dashboard/settings/software': 'Software',
-			'/dashboard/settings/developer': 'Developer',
 			'/dashboard/osm': 'Maps',
 			'/dashboard/preferences': 'Preferences',
 			'/dashboard/whats-new': "What's new"
 		};
-		return `sunnylink${titles[path] ? ` - ${titles[path]}` : ''}`;
+
+		if (staticTitles[path]) return `sunnylink - ${staticTitles[path]}`;
+
+		if (path.startsWith('/dashboard/settings/')) {
+			const category = path.slice('/dashboard/settings/'.length);
+			const schema = deviceState.selectedDeviceId
+				? schemaState.schemas[deviceState.selectedDeviceId]
+				: undefined;
+			const panel = schema?.panels.find((p) => p.id === category);
+			if (panel?.label) return `sunnylink - ${panel.label}`;
+			if (category) return `sunnylink - Settings`;
+		}
+
+		return 'sunnylink';
 	};
 
 	const closeDrawerOnMobile = () => {
@@ -277,20 +272,29 @@
 			? [
 					{
 						label: 'Device Settings',
-						items: [
-							{ icon: HardDrive, label: 'Device', href: '/dashboard/settings/device' },
-							{ icon: ToggleLeft, label: 'Toggles', href: '/dashboard/settings/toggles' },
-							{ icon: Bot, label: 'Models', href: '/dashboard/models' },
-							{ icon: Gauge, label: 'Steering', href: '/dashboard/settings/steering' },
-							{ icon: Wind, label: 'Cruise', href: '/dashboard/settings/cruise' },
-							{ icon: Palette, label: 'Visuals', href: '/dashboard/settings/visuals' },
-							{ icon: Monitor, label: 'Display', href: '/dashboard/settings/display' },
-							{ icon: MapIcon, label: 'Maps', href: '/dashboard/osm' },
-							{ icon: Car, label: 'Vehicle', href: '/dashboard/settings/vehicle' },
-							{ icon: Package, label: 'Software', href: '/dashboard/settings/software' },
-							{ icon: Wrench, label: 'Developer', href: '/dashboard/settings/developer' }
-						]
-					}
+						items: getBuiltinNavItems().map((item) => ({
+							icon: item.icon,
+							label: item.label,
+							href: item.href
+						}))
+					},
+					...(() => {
+						const customItems = getCustomSchemaNavItems(
+							schemaState.schemas[deviceState.selectedDeviceId]
+						);
+						return customItems.length > 0
+							? [
+									{
+										label: 'Custom Device Settings',
+										items: customItems.map((item) => ({
+											icon: item.icon,
+											label: item.label,
+											href: item.href
+										}))
+									}
+								]
+							: [];
+					})()
 				]
 			: []
 	);


### PR DESCRIPTION
Hopefully addressing: https://github.com/sunnypilot/sunnylink-frontend/issues/84

The goal is to allow forks of SunnyPilot to have the pages they expose, via `settings_ui.json`, to be shown in the navigation within SunnyLink,