### PR TITLE
fix: false 'changed on device' drift on float settings

### DIFF
--- a/src/lib/utils/device.ts
+++ b/src/lib/utils/device.ts
@@ -60,8 +60,14 @@ export function encodeParamValue(param: { key: string; value: any; type: string 
 				stringValue = param.value ? '1' : '0';
 				break;
 			case 'Int':
-			case 'Float':
 				stringValue = String(param.value);
+				break;
+			case 'Float':
+				// Round to 2dp to match decodeParamValue's readback rounding.
+				// Slider step arithmetic produces imprecise floats (0.01 * 15 =
+				// 0.14999999999999999); storing the raw string makes the drift
+				// comparison flag a false "changed on device".
+				stringValue = String(Number(param.value.toFixed(2)));
 				break;
 			case 'Json':
 				stringValue = typeof param.value === 'string' ? param.value : JSON.stringify(param.value);

--- a/src/lib/utils/drift.ts
+++ b/src/lib/utils/drift.ts
@@ -28,6 +28,7 @@ export interface DriftEntry {
 function normalize(value: unknown): string {
 	if (value === undefined || value === null) return '';
 	if (typeof value === 'boolean') return value ? '1' : '0';
+	if (typeof value === 'number') return String(Number(value.toFixed(2)));
 	return String(value);
 }
 


### PR DESCRIPTION
## Problem

Float settings set via slider steps get false "changed on device" flags.

Slider step arithmetic produces imprecise JS floats: `0.01 * 15 = 0.14999999999999999`. The chain:

1. `encodeParamValue` stored the raw string (`"0.14999999999999999"`) on the device
2. `decodeParamValue` rounds readbacks to 2dp (`0.15`)
3. `detectDrift` compared `String(baseline)` against `String(fresh)` with no rounding on the baseline side: `"0.14999999999999999"` vs `"0.15"` → false drift

Affects any float widget (option sliders) adjusted by steps, regardless of the underlying param type.

## Fix

- `encodeParamValue` rounds floats to 2dp before sending, so the stored value matches the decoded comparison
- `normalize()` in drift.ts rounds numbers to 2dp as belt-and-braces for any cached float that slipped through

Both fixes are one-liners; verified against real slider-step values (`0.01*15`, `0.1+0.05`, `0.2-0.05`).