### PR TITLE
fix(settings): convert canonical values for display units

### DIFF
--- a/src/lib/components/schema/SchemaItemRenderer.svelte
+++ b/src/lib/components/schema/SchemaItemRenderer.svelte
@@ -21,6 +21,12 @@
 	import { Info, Loader2 } from 'lucide-svelte';
 	import SelectDropdown from '$lib/components/SelectDropdown.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
+	import {
+		resolveValueTransform,
+		toDisplayStep,
+		toDisplayValue,
+		toStoredValue
+	} from '$lib/utils/valueTransform';
 	import { toast } from 'svelte-sonner';
 	import SchemaItemRenderer from './SchemaItemRenderer.svelte';
 
@@ -146,7 +152,24 @@
 	});
 
 	let currentValue = $derived(deviceState.deviceValues[deviceId]?.[item.key]);
-	let displayValue: unknown = $derived(currentValue);
+	let isMetric = $derived.by(() => {
+		const value = ruleContext.paramValues?.['IsMetric'];
+		return value === true || value === 1 || value === '1';
+	});
+	let valueTransform = $derived(resolveValueTransform(item.value_transform, isMetric));
+	let displayValue: unknown = $derived(
+		typeof currentValue === 'number' ? toDisplayValue(currentValue, valueTransform) : currentValue
+	);
+	let displayMin = $derived(
+		item.min !== undefined ? toDisplayValue(item.min, valueTransform) : undefined
+	);
+	let displayMax = $derived(
+		item.max !== undefined ? toDisplayValue(item.max, valueTransform) : undefined
+	);
+	let displayStep = $derived(toDisplayStep(item.step, valueTransform));
+	let displayPrecision = $derived(
+		valueTransform?.precision ?? (displayStep !== undefined && displayStep < 1 ? 2 : 0)
+	);
 
 	function isOptionEnabled(option: SchemaOption): boolean {
 		if (!option.enablement || option.enablement.length === 0) return true;
@@ -175,16 +198,18 @@
 	});
 
 	let isLoading = $derived(loadingValues && currentValue === undefined);
-	let isFloat = $derived(item.step !== undefined && item.step < 1);
+	let isFloat = $derived(
+		displayPrecision > 0 ||
+			(displayStep !== undefined && !Number.isInteger(displayStep)) ||
+			(displayMin !== undefined && !Number.isInteger(displayMin)) ||
+			(displayMax !== undefined && !Number.isInteger(displayMax))
+	);
 	let isOn = $derived(displayValue === true || displayValue === 1 || displayValue === '1');
 
 	let resolvedUnit = $derived.by(() => {
 		if (!item.unit) return undefined;
 		if (typeof item.unit === 'string') return item.unit;
-		const isMetric = ruleContext.paramValues?.['IsMetric'];
-		return isMetric === true || isMetric === 1 || isMetric === '1'
-			? item.unit.metric
-			: item.unit.imperial;
+		return isMetric ? item.unit.metric : item.unit.imperial;
 	});
 
 	// Live slider preview: shows value during drag, resets on release
@@ -218,6 +243,7 @@
 	let hasDrift = $derived(refreshBanner.getAll(deviceId).some((e) => e.key === item.key));
 
 	function inferParamType(): string {
+		if (item.value_transform) return 'Float';
 		const deviceParams = deviceState.deviceSettings[deviceId];
 		if (deviceParams) {
 			const paramInfo = deviceParams.find((p) => p.key === item.key);
@@ -259,7 +285,11 @@
 	}
 
 	function handleChange(newValue: unknown) {
-		pushValue(newValue);
+		// Display rounding can make a canonical endpoint look equal to a transformed
+		// bound (for example, 20 mph and 32 km/h). Do not re-quantize the stored
+		// value when the user cannot see any display-space change.
+		if (newValue === displayValue) return;
+		pushValue(typeof newValue === 'number' ? toStoredValue(newValue, valueTransform) : newValue);
 	}
 
 	// Row-level left accent for push/queue/drift feedback
@@ -283,7 +313,9 @@
 
 	function formatDisplay(val: unknown): string {
 		if (val === undefined || val === null) return '-';
-		if (isFloat && typeof val === 'number') return val.toFixed(2);
+		if (typeof val === 'number' && (valueTransform || isFloat)) {
+			return val.toFixed(displayPrecision);
+		}
 		return String(val);
 	}
 
@@ -750,7 +782,7 @@
 				{/if}
 			</div>
 		</div>
-	{:else if item.widget === 'option' && item.min !== undefined && item.max !== undefined}
+	{:else if item.widget === 'option' && displayMin !== undefined && displayMax !== undefined}
 		<!-- ── Slider Row (range input below label) ────────────────────── -->
 		<div class="px-4 py-4">
 			<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
@@ -835,20 +867,20 @@
 				{:else}
 					<div class="flex w-full flex-col gap-2">
 						<div class="flex items-center justify-between text-xs text-[var(--sl-text-3)]">
-							<span>{isFloat ? Number(item.min).toFixed(2) : item.min}</span>
+							<span>{formatDisplay(displayMin)}</span>
 							<span
 								class="text-sm font-semibold tabular-nums transition-colors"
 								class:text-primary={sliderPreview === null}
 								class:text-[var(--sl-text-1)]={sliderPreview !== null}
 							>
 								{formatDisplay(
-									sliderPreview ?? (displayValue !== undefined ? displayValue : item.min)
+									sliderPreview ?? (displayValue !== undefined ? displayValue : displayMin)
 								)}
 								{#if resolvedUnit}<span class="ml-0.5 text-xs font-normal text-[var(--sl-text-3)]"
 										>{resolvedUnit}</span
 									>{/if}
 							</span>
-							<span>{isFloat ? Number(item.max).toFixed(2) : item.max}</span>
+							<span>{formatDisplay(displayMax)}</span>
 						</div>
 						<div
 							class="flex items-center gap-2 transition-opacity duration-200"
@@ -857,13 +889,12 @@
 						>
 							<button
 								class="flex h-10 w-10 items-center justify-center rounded-lg text-[var(--sl-text-3)] transition-all duration-100 hover:bg-[var(--sl-bg-elevated)] hover:text-[var(--sl-text-1)] active:scale-[0.88] active:bg-[var(--sl-bg-subtle)] disabled:active:scale-100"
-								disabled={!enabled || isPushing}
+								disabled={!enabled || isPushing || Number(displayValue ?? displayMin) <= displayMin}
 								aria-label="Decrease {item.title}"
 								onclick={() => {
-									const current =
-										displayValue !== undefined ? Number(displayValue) : Number(item.min);
-									const nv = Math.max(item.min!, current - (item.step || 1));
-									handleChange(isFloat ? parseFloat(nv.toFixed(2)) : nv);
+									const current = displayValue !== undefined ? Number(displayValue) : displayMin;
+									const nv = Math.max(displayMin, current - (displayStep || 1));
+									handleChange(isFloat ? parseFloat(nv.toFixed(displayPrecision)) : nv);
 								}}
 							>
 								<svg
@@ -880,10 +911,10 @@
 							</button>
 							<input
 								type="range"
-								min={item.min}
-								max={item.max}
-								step={item.step || 1}
-								value={displayValue !== undefined ? Number(displayValue) : item.min}
+								min={displayMin}
+								max={displayMax}
+								step={displayStep || 1}
+								value={displayValue !== undefined ? Number(displayValue) : displayMin}
 								class="range flex-1 range-primary range-xs"
 								disabled={!enabled || isPushing}
 								onpointerdown={startSliderDrag}
@@ -916,13 +947,12 @@
 							/>
 							<button
 								class="flex h-10 w-10 items-center justify-center rounded-lg text-[var(--sl-text-3)] transition-all duration-100 hover:bg-[var(--sl-bg-elevated)] hover:text-[var(--sl-text-1)] active:scale-[0.88] active:bg-[var(--sl-bg-subtle)] disabled:active:scale-100"
-								disabled={!enabled || isPushing}
+								disabled={!enabled || isPushing || Number(displayValue ?? displayMax) >= displayMax}
 								aria-label="Increase {item.title}"
 								onclick={() => {
-									const current =
-										displayValue !== undefined ? Number(displayValue) : Number(item.min);
-									const nv = Math.min(item.max!, current + (item.step || 1));
-									handleChange(isFloat ? parseFloat(nv.toFixed(2)) : nv);
+									const current = displayValue !== undefined ? Number(displayValue) : displayMin;
+									const nv = Math.min(displayMax, current + (displayStep || 1));
+									handleChange(isFloat ? parseFloat(nv.toFixed(displayPrecision)) : nv);
 								}}
 							>
 								<svg

--- a/src/lib/components/schema/SchemaItemRenderer.svelte.spec.ts
+++ b/src/lib/components/schema/SchemaItemRenderer.svelte.spec.ts
@@ -1,0 +1,110 @@
+import { tick } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { cleanup, render } from 'vitest-browser-svelte';
+import { deviceState } from '$lib/stores/device.svelte';
+import { pendingChanges } from '$lib/stores/pendingChanges.svelte';
+import type { SchemaItem } from '$lib/types/schema';
+import SchemaItemRenderer from './SchemaItemRenderer.svelte';
+
+const DEVICE_ID = 'value-transform-test-device';
+const MPH_TO_KPH = 1.609344;
+
+const laneTurnItem: SchemaItem = {
+	key: 'LaneTurnValue',
+	title: 'Adjust lane turn speed',
+	widget: 'option',
+	min: 0,
+	max: 20,
+	step: 1,
+	unit: { metric: 'km/h', imperial: 'mph' },
+	value_transform: {
+		metric: { scale: MPH_TO_KPH, precision: 0, step: 1 },
+		imperial: { scale: 1, precision: 0, step: 1 }
+	}
+};
+
+function seedDevice(storedValue: number, isMetric = true): void {
+	pendingChanges.clearAll(DEVICE_ID);
+	deviceState.deviceValues[DEVICE_ID] = {
+		LaneTurnValue: storedValue,
+		IsMetric: isMetric ? 1 : 0
+	};
+	deviceState.onlineStatuses[DEVICE_ID] = 'offline';
+}
+
+afterEach(() => {
+	cleanup();
+	pendingChanges.clearAll(DEVICE_ID);
+	delete deviceState.deviceValues[DEVICE_ID];
+	delete deviceState.onlineStatuses[DEVICE_ID];
+});
+
+describe('SchemaItemRenderer value transforms', () => {
+	it('does not rewrite a canonical maximum that rounds to the display maximum', async () => {
+		seedDevice(20);
+		const rendered = render(SchemaItemRenderer, { deviceId: DEVICE_ID, item: laneTurnItem });
+
+		const increase = page.getByRole('button', { name: 'Increase Adjust lane turn speed' });
+		await expect.element(increase).toBeDisabled();
+		expect(rendered.container.textContent).toContain('32 km/h');
+		expect(rendered.container.textContent).not.toContain('32.0');
+		expect(deviceState.deviceValues[DEVICE_ID]?.LaneTurnValue).toBe(20);
+		expect(pendingChanges.getForKey(DEVICE_ID, 'LaneTurnValue')).toBeUndefined();
+	});
+
+	it('writes the canonical mph value when increasing from 31 to 32 km/h', async () => {
+		seedDevice(31 / MPH_TO_KPH);
+		render(SchemaItemRenderer, { deviceId: DEVICE_ID, item: laneTurnItem });
+
+		await page.getByRole('button', { name: 'Increase Adjust lane turn speed' }).click();
+
+		const expectedStored = 32 / MPH_TO_KPH;
+		expect(deviceState.deviceValues[DEVICE_ID]?.LaneTurnValue).toBeCloseTo(expectedStored, 10);
+		expect(pendingChanges.getForKey(DEVICE_ID, 'LaneTurnValue')?.desiredValue).toBeCloseTo(
+			expectedStored,
+			10
+		);
+	});
+
+	it('switches units without changing the canonical value', async () => {
+		seedDevice(20);
+		const rendered = render(SchemaItemRenderer, { deviceId: DEVICE_ID, item: laneTurnItem });
+		expect(rendered.container.textContent).toContain('32 km/h');
+
+		deviceState.deviceValues[DEVICE_ID]!.IsMetric = 0;
+		await tick();
+
+		expect(rendered.container.textContent).toContain('20 mph');
+		expect(deviceState.deviceValues[DEVICE_ID]?.LaneTurnValue).toBe(20);
+		expect(pendingChanges.getForKey(DEVICE_ID, 'LaneTurnValue')).toBeUndefined();
+	});
+
+	it('honors transformed display precision and step without a canonical step', async () => {
+		seedDevice(20);
+		deviceState.deviceValues[DEVICE_ID]!.PrecisionValue = 1.25;
+		const precisionItem: SchemaItem = {
+			key: 'PrecisionValue',
+			title: 'Precision value',
+			widget: 'option',
+			min: 0,
+			max: 10,
+			unit: 'widgets',
+			value_transform: {
+				metric: { scale: 1, precision: 3, step: 0.001 }
+			}
+		};
+
+		const rendered = render(SchemaItemRenderer, {
+			deviceId: DEVICE_ID,
+			item: precisionItem
+		});
+		const input = rendered.container.querySelector<HTMLInputElement>('input[type="range"]');
+
+		expect(input?.step).toBe('0.001');
+		expect(rendered.container.textContent).toContain('1.250 widgets');
+
+		await page.getByRole('button', { name: 'Increase Precision value' }).click();
+		expect(deviceState.deviceValues[DEVICE_ID]?.PrecisionValue).toBe(1.251);
+	});
+});

--- a/src/lib/types/schema.ts
+++ b/src/lib/types/schema.ts
@@ -89,6 +89,17 @@ export interface SchemaOption {
 	enablement?: Rule[];
 }
 
+export interface ValueTransform {
+	scale: number;
+	precision: number;
+	step?: number;
+}
+
+export interface ValueTransformByUnit {
+	metric?: ValueTransform;
+	imperial?: ValueTransform;
+}
+
 export interface SchemaItem {
 	key: string;
 	widget: WidgetType;
@@ -102,6 +113,7 @@ export interface SchemaItem {
 	max?: number;
 	step?: number;
 	unit?: string | { metric: string; imperial: string };
+	value_transform?: ValueTransformByUnit;
 	value_map?: Record<string, number>;
 	visibility?: Rule[];
 	enablement?: Rule[];

--- a/src/lib/utils/valueTransform.spec.ts
+++ b/src/lib/utils/valueTransform.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { ValueTransformByUnit } from '$lib/types/schema';
+import {
+	resolveValueTransform,
+	toDisplayStep,
+	toDisplayValue,
+	toStoredValue
+} from './valueTransform';
+
+const laneTurnTransforms: ValueTransformByUnit = {
+	metric: { scale: 1.609344, precision: 0, step: 1 },
+	imperial: { scale: 1, precision: 0, step: 1 }
+};
+
+describe('value transforms', () => {
+	it('converts the lane turn range to whole km/h', () => {
+		const transform = resolveValueTransform(laneTurnTransforms, true);
+		expect(toDisplayValue(0, transform)).toBe(0);
+		expect(toDisplayValue(20, transform)).toBe(32);
+		expect(toDisplayStep(1, transform)).toBe(1);
+	});
+
+	it('converts displayed metric values back to canonical mph', () => {
+		const transform = resolveValueTransform(laneTurnTransforms, true);
+		const stored = toStoredValue(32, transform);
+		expect(stored).toBeCloseTo(19.883878, 6);
+		expect(toDisplayValue(stored, transform)).toBe(32);
+	});
+
+	it('keeps imperial display values in whole mph', () => {
+		const transform = resolveValueTransform(laneTurnTransforms, false);
+		expect(toDisplayValue(19.883878, transform)).toBe(20);
+		expect(toStoredValue(20, transform)).toBe(20);
+	});
+
+	it('is an identity transform when no metadata is provided', () => {
+		expect(resolveValueTransform(undefined, true)).toBeUndefined();
+		expect(toDisplayValue(12.5, undefined)).toBe(12.5);
+		expect(toStoredValue(12.5, undefined)).toBe(12.5);
+		expect(toDisplayStep(0.5, undefined)).toBe(0.5);
+	});
+
+	it('uses an explicit display step without requiring a canonical step', () => {
+		const transform = { scale: 1.609344, precision: 3, step: 0.001 };
+		expect(toDisplayStep(undefined, transform)).toBe(0.001);
+	});
+});

--- a/src/lib/utils/valueTransform.ts
+++ b/src/lib/utils/valueTransform.ts
@@ -1,0 +1,27 @@
+import type { ValueTransform, ValueTransformByUnit } from '$lib/types/schema';
+
+export function resolveValueTransform(
+	transforms: ValueTransformByUnit | undefined,
+	isMetric: boolean
+): ValueTransform | undefined {
+	return isMetric ? transforms?.metric : transforms?.imperial;
+}
+
+export function toDisplayValue(value: number, transform: ValueTransform | undefined): number {
+	if (!transform || !Number.isFinite(value) || transform.scale <= 0) return value;
+	return Number((value * transform.scale).toFixed(transform.precision));
+}
+
+export function toStoredValue(value: number, transform: ValueTransform | undefined): number {
+	if (!transform || !Number.isFinite(value) || transform.scale <= 0) return value;
+	return value / transform.scale;
+}
+
+export function toDisplayStep(
+	step: number | undefined,
+	transform: ValueTransform | undefined
+): number | undefined {
+	if (transform?.step !== undefined) return transform.step;
+	if (step === undefined) return undefined;
+	return toDisplayValue(step, transform);
+}


### PR DESCRIPTION
## Summary

- support optional per-unit numeric transforms from the device settings schema
- render transformed slider values, bounds, steps, and precision while keeping optimistic state canonical
- inverse-convert writes and suppress rounded display-space no-op writes
- add browser coverage for integer lane-turn values, metric/imperial switching, boundary behavior, and transform precision

## Why

This is the frontend companion for sunnypilot/sunnypilot#1888. `LaneTurnValue` is stored and interpreted as mph, but Sunnylink previously changed only the unit label when `IsMetric` was enabled. With the companion schema metadata, metric users see an integer 0–32 km/h range while the device continues to store mph.

Main schema PR: sunnypilot/sunnypilot#1985.

## Testing

- `pnpm check` — 0 errors and 0 warnings
- `pnpm lint`
- `vitest run --coverage` — 99 tests passed, including Chromium component tests
- `pnpm build`

Assisted by OpenAI Codex; the commit includes the repository-required disclosure.
